### PR TITLE
Various Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,44 +5,44 @@ on:
         branches: [ main, master ]
     pull_request:
         branches: [ main, master ]
+    workflow_dispatch:
 
 jobs:
     build:
         runs-on: ubuntu-latest
+        container:
+            image: mono:6.12.0.182   # includes msbuild; don't apt-get inside
         
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
+            - uses: actions/checkout@v4
 
-            - name: Install Mono (msbuild, mono runtime)
+            - name: Show tool versions
               run: |
-                  sudo apt-get update
-                  sudo apt-get install -y mono-complete
                   mono --version
                   msbuild /version
-
-            - name: Cache NuGet artifacts
-              uses: actions/cache@v4
-              with:
-                  path: |
-                      packages
-                      ~/.nuget/packages
-                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config', '**/*.csproj', '**/*.sln') }}
-                  restore-keys: |
-                      ${{ runner.os }}-nuget-
 
             - name: Download nuget.exe
               run: |
                   mkdir -p tools
-                  curl -L https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -o tools/nuget.exe
+                  curl -sSL https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -o tools/nuget.exe
                   mono tools/nuget.exe help | head -n 1
 
-            - name: Restore NuGet packages
-              run: mono tools/nuget.exe restore OrbitPOInts.sln
+            - name: Cache NuGet
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      packages
+                      /root/.nuget/packages
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config', '**/*.csproj', '**/*.sln') }}
+                  restore-keys: |
+                      ${{ runner.os }}-nuget-
 
-            - name: Ensure NUnit console runner
+            - name: Restore packages
+              run: mono tools/nuget.exe restore OrbitPOInts.sln -NonInteractive
+
+            - name: Ensure NUnit console
               run: mono tools/nuget.exe install NUnit.ConsoleRunner -Version 3.16.3 -OutputDirectory packages
-            
+
             - name: Build
               env:
                   CONFIG: Test
@@ -51,6 +51,12 @@ jobs:
             - name: Test
               env:
                   CONFIG: Test
-              run: |
-                  mono ./packages/NUnit.ConsoleRunner.3.16.3/tools/nunit3-console.exe \
-                    ./OrbitPOInts.Tests/bin/${CONFIG}/OrbitPOInts.Tests.dll
+              run: mono ./packages/NUnit.ConsoleRunner.3.16.3/tools/nunit3-console.exe --result="TestResult.xml;format=nunit3" "./OrbitPOInts.Tests/bin/${CONFIG}/OrbitPOInts.Tests.dll"
+
+    
+            - name: Upload test results
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: nunit-results
+                  path: TestResult.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,10 @@ on:
     workflow_dispatch:
 
 jobs:
-    build:
+    setup:
         runs-on: ubuntu-latest
         container:
-            image: mono:6.12.0.182   # includes msbuild; don't apt-get inside
-        
+            image: mono:6.12.0.182
         steps:
             - uses: actions/checkout@v4
 
@@ -42,18 +41,83 @@ jobs:
 
             - name: Ensure NUnit console
               run: mono tools/nuget.exe install NUnit.ConsoleRunner -Version 3.16.3 -OutputDirectory packages
+    
+    build:
+        needs: setup
+        runs-on: ubuntu-latest
+        container:
+            image: mono:6.12.0.182
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Download nuget.exe
+              run: |
+                  mkdir -p tools
+                  curl -sSL https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -o tools/nuget.exe
+
+            - name: Restore NuGet cache
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      packages
+                      /root/.nuget/packages
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config', '**/*.csproj', '**/*.sln') }}
+                  restore-keys: |
+                      ${{ runner.os }}-nuget-
+
+            - name: Restore (no-op if cached)
+              run: mono tools/nuget.exe restore OrbitPOInts.sln -NonInteractive
 
             - name: Build
               env:
                   CONFIG: Test
               run: msbuild OrbitPOInts.sln /p:Configuration=${CONFIG} /verbosity:minimal
 
+            - name: Upload build outputs
+              uses: actions/upload-artifact@v4
+              with:
+                  name: build-binaries
+                  path: |
+                      OrbitPOInts/bin/Test/
+                      OrbitPOInts.Tests/bin/Test/
+    
+    test:
+        needs: build
+        runs-on: ubuntu-latest
+        container:
+            image: mono:6.12.0.182
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Download build outputs
+              uses: actions/download-artifact@v4
+              with:
+                  name: build-binaries
+                  path: .  # put files back at repo root so the same path works
+
+            - name: Download nuget.exe
+              run: |
+                  mkdir -p tools
+                  curl -sSL https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -o tools/nuget.exe
+
+            - name: Restore NuGet cache
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      packages
+                      /root/.nuget/packages
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config', '**/*.csproj', '**/*.sln') }}
+                  restore-keys: |
+                      ${{ runner.os }}-nuget-
+
+            - name: Ensure NUnit console
+              run: mono tools/nuget.exe install NUnit.ConsoleRunner -Version 3.16.3 -OutputDirectory packages
+
             - name: Test
               env:
                   CONFIG: Test
               run: mono ./packages/NUnit.ConsoleRunner.3.16.3/tools/nunit3-console.exe --result="TestResult.xml;format=nunit3" "./OrbitPOInts.Tests/bin/${CONFIG}/OrbitPOInts.Tests.dll"
 
-    
             - name: Upload test results
               if: always()
               uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,56 @@
 name: Mono CI
 
 on:
-  push:
-    branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
+    push:
+        branches: [ main, master ]
+    pull_request:
+        branches: [ main, master ]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    container:
-      image: mono:latest
+    build:
+        runs-on: ubuntu-latest
+        
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
 
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+            - name: Install Mono (msbuild, mono runtime)
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y mono-complete
+                  mono --version
+                  msbuild /version
 
-    - name: Setup NuGet
-      run: apt-get update && apt-get install -y nuget
+            - name: Cache NuGet artifacts
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      packages
+                      ~/.nuget/packages
+                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config', '**/*.csproj', '**/*.sln') }}
+                  restore-keys: |
+                      ${{ runner.os }}-nuget-
 
-    - name: Restore NuGet packages
-      run: nuget restore
+            - name: Download nuget.exe
+              run: |
+                  mkdir -p tools
+                  curl -L https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -o tools/nuget.exe
+                  mono tools/nuget.exe help | head -n 1
 
-    - name: Build
-      run: msbuild /p:Configuration=Test
+            - name: Restore NuGet packages
+              run: mono tools/nuget.exe restore OrbitPOInts.sln
 
-    - name: Test
-      run: mono ./packages/NUnit.ConsoleRunner.3.16.3/tools/nunit3-console.exe ./OrbitPOInts.Tests/bin/Test/OrbitPOInts.Tests.dll
+            - name: Ensure NUnit console runner
+              run: mono tools/nuget.exe install NUnit.ConsoleRunner -Version 3.16.3 -OutputDirectory packages
+            
+            - name: Build
+              env:
+                  CONFIG: Test
+              run: msbuild OrbitPOInts.sln /p:Configuration=${CONFIG} /verbosity:minimal
+
+            - name: Test
+              env:
+                  CONFIG: Test
+              run: |
+                  mono ./packages/NUnit.ConsoleRunner.3.16.3/tools/nunit3-console.exe \
+                    ./OrbitPOInts.Tests/bin/${CONFIG}/OrbitPOInts.Tests.dll

--- a/KSPMock/CelestialBody.cs
+++ b/KSPMock/CelestialBody.cs
@@ -19,6 +19,8 @@ namespace KSPMock
         public Orbit orbit;
         // TODO: OrbitDriver not stubbed
         // public OrbitDriver orbitDriver;
+        // required initialized for tests
+        public PQS pqsController = new();
 
         public MapObject MapObject;
 
@@ -111,6 +113,11 @@ namespace KSPMock
         public static bool operator false(CelestialBody body)
         {
             return body == null;
+        }
+        
+        public double GetRelSurfaceNVector(double lat, double lon)
+        {
+            return 0;
         }
     }
 }

--- a/KSPMock/FlightGlobals.cs
+++ b/KSPMock/FlightGlobals.cs
@@ -7,5 +7,6 @@ namespace KSPMock
         public static List<CelestialBody> Bodies;
 
         public static FlightGlobals fetch;
+        public static bool ready;
     }
 }

--- a/KSPMock/KSPMock.csproj
+++ b/KSPMock/KSPMock.csproj
@@ -66,6 +66,7 @@
         <Compile Include="Orbit.cs" />
         <Compile Include="Part.cs" />
         <Compile Include="PlanetariumCamera.cs" />
+        <Compile Include="PQS.cs" />
         <Compile Include="Properties\AssemblyInfo.cs"/>
         <Compile Include="ScaledSpace.cs" />
         <Compile Include="ScenarioCreationOptions.cs" />

--- a/KSPMock/PQS.cs
+++ b/KSPMock/PQS.cs
@@ -6,6 +6,7 @@ namespace KSPMock
     {
         // needs to be set for tests expecting PQS to be active
         public bool isActiveAndEnabled = true;
+
         public double GetSurfaceHeight(double radial)
         {
             return 0;

--- a/KSPMock/PQS.cs
+++ b/KSPMock/PQS.cs
@@ -1,0 +1,14 @@
+using UnityEngineMock;
+
+namespace KSPMock
+{
+    public class PQS : MonoBehaviour
+    {
+        // needs to be set for tests expecting PQS to be active
+        public bool isActiveAndEnabled = true;
+        public double GetSurfaceHeight(double radial)
+        {
+            return 0;
+        }
+    }
+}

--- a/OrbitPOInts.Tests/CelestialBodyCacheTests.cs
+++ b/OrbitPOInts.Tests/CelestialBodyCacheTests.cs
@@ -17,6 +17,7 @@ namespace OrbitPOInts.Tests
         [OneTimeSetUp]
         public void OneTimeSetup()
         {
+            HighLogic.LoadedScene = GameScenes.TRACKSTATION;
             var mockTerrainService = new Mock<ITerrainService>();
             mockTerrainService.Setup(c => c.TerrainAltitude(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>())).Returns(1);
             testBody = new MockCelestialBody(mockTerrainService.Object)

--- a/OrbitPOInts.Tests/Data/PoiCompareTests.cs
+++ b/OrbitPOInts.Tests/Data/PoiCompareTests.cs
@@ -18,6 +18,7 @@ namespace OrbitPOInts.Tests.Data
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
+            HighLogic.LoadedScene = GameScenes.TRACKSTATION;
             var mockTerrainService = new Mock<ITerrainService>();
             mockTerrainService.Setup(c => c.TerrainAltitude(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>())).Returns(1);
             testBody = new MockCelestialBody(mockTerrainService.Object)

--- a/OrbitPOInts.Tests/ModScenarioTests.cs
+++ b/OrbitPOInts.Tests/ModScenarioTests.cs
@@ -28,6 +28,7 @@ namespace OrbitPOInts.Tests
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
+            HighLogic.LoadedScene = GameScenes.TRACKSTATION;
             _serializerOptions = new JsonSerializerOptions
             {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,

--- a/OrbitPOInts.Tests/SettingsE2ETests.cs
+++ b/OrbitPOInts.Tests/SettingsE2ETests.cs
@@ -56,6 +56,7 @@ namespace OrbitPOInts.Tests
         [OneTimeSetUp]
         public void OneTimeSetup()
         {
+            HighLogic.LoadedScene = GameScenes.TRACKSTATION;
             var mockTerrainService = new Mock<ITerrainService>();
             mockTerrainService.Setup(c => c.TerrainAltitude(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>())).Returns(1);
             testBody = new MockCelestialBody(mockTerrainService.Object)

--- a/OrbitPOInts.Tests/SettingsTests.cs
+++ b/OrbitPOInts.Tests/SettingsTests.cs
@@ -19,6 +19,7 @@ namespace OrbitPOInts.Tests
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
+            HighLogic.LoadedScene = GameScenes.TRACKSTATION;
             var mockTerrainService = new Mock<ITerrainService>();
             mockTerrainService.Setup(c => c.TerrainAltitude(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>())).Returns(1);
             testBody = new MockCelestialBody(mockTerrainService.Object)

--- a/OrbitPOInts/CelestialBodyCache.cs
+++ b/OrbitPOInts/CelestialBodyCache.cs
@@ -28,7 +28,8 @@ namespace OrbitPOInts
     {
         private static CelestialBodyCache _instance;
         private IReadOnlyDictionary<string, CelestialBody> _nameToBodyDictionary;
-        private ReadOnlyDictionary<CelestialBody,double> _bodyToMaxAltitudeDictionary;
+        private Dictionary<CelestialBody,double> _bodyToMaxAltitudeDictionary;
+        private ReadOnlyDictionary<CelestialBody, double> _bodyToMaxAltitudeDictionaryRO;
 
         public static CelestialBodyCache Instance => _instance ??= new CelestialBodyCache();
         public IReadOnlyDictionary<string, CelestialBody> NameToBodyDictionary => _nameToBodyDictionary ??= new ReadOnlyDictionary<string, CelestialBody>(FlightGlobals.Bodies.ToDictionary(body => body.name));
@@ -37,43 +38,97 @@ namespace OrbitPOInts
         {
             get
             {
-                if (_bodyToMaxAltitudeDictionary != null) return _bodyToMaxAltitudeDictionary;
+                UpdateFailed();
+                if (_bodyToMaxAltitudeDictionaryRO != null) return _bodyToMaxAltitudeDictionaryRO;
+                _bodyToMaxAltitudeDictionary = Initialize();
+                _bodyToMaxAltitudeDictionaryRO = new ReadOnlyDictionary<CelestialBody, double>(_bodyToMaxAltitudeDictionary);
+                return _bodyToMaxAltitudeDictionaryRO;
+            }
+        }
+        
+        private readonly HashSet<CelestialBody> _bodyFailedMaxAltitudeSet = new();
 
-                var dict = new Dictionary<CelestialBody,double>();
-                var bodies = FlightGlobals.Bodies ?? new List<CelestialBody>();
+        /// <summary>
+        /// Attempts to update the max altitude for bodies that failed to be sampled.
+        /// </summary>
+        private void UpdateFailed()
+        {
+            if (_bodyFailedMaxAltitudeSet.Count == 0) return;
+            foreach (var body in _bodyFailedMaxAltitudeSet.ToArray())
+            {
+                UpdateBodyMaxAltitude(body, out var value);
+                _bodyToMaxAltitudeDictionary[body] = value;
+            } 
+        }
 
-                foreach (var body in bodies.Where(body => body))
+        /// <summary>
+        /// Attempts to get the max altitude for a body.
+        /// </summary>
+        /// <param name="body"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private static bool TryGetBodyMaxAltitude(CelestialBody body, out double value)
+        {
+            value = body.Radius; // fallback
+                    
+            try
+            {
+                // Skip bodies without usable PQS (e.g., Sun, some gas giants or not ready)
+                if (!body.IsPqsUsable())
                 {
-                    var value = body.Radius; // fallback
-                    
-                    try
-                    {
-                        // Skip bodies without usable PQS (e.g., Sun, some gas giants or not ready)
-                        if (!body.IsPqsUsable())
-                        {
-                            Debug.LogWarning($"[OrbitPOInts] Skipping {body.bodyName} (no usable PQS).");
-                            continue;
-                        }
-
-                        var max = body.GetApproxTerrainMaxHeight(/*res*/ 32);
-                        // store absolute surface radius at max terrain
-                        value = body.Radius + Math.Max(0, max);
-                        
-                        Debug.Log($"[OrbitPOInts] Cached {body.bodyName}: max terrain alt {value:N0} m");
-                    }
-                    catch (Exception ex)
-                    {
-                        // Skip bad body instead of failing the whole map
-                        Debug.LogError($"[OrbitPOInts] Failed sampling {body?.bodyName ?? "<null>"}: {ex}");
-                    }
-                    
-                    // IMPORTANT: always add the body, even if PQS was not used
-                    dict[body] = value;
+                    Debug.LogWarning($"[OrbitPOInts] Skipping {body.bodyName} (no usable PQS).");
+                    return false;
                 }
 
-                _bodyToMaxAltitudeDictionary = new ReadOnlyDictionary<CelestialBody,double>(dict);
-                return _bodyToMaxAltitudeDictionary;
+                var max = body.GetApproxTerrainMaxHeight(/*res*/ 32);
+                // store absolute surface radius at max terrain
+                value = body.Radius + Math.Max(0, max);
+                        
+                Debug.Log($"[OrbitPOInts] Cached {body.bodyName}: max terrain alt {value:N0} m");
             }
+            catch (Exception ex)
+            {
+                // Skip bad body instead of failing the whole map
+                Debug.LogError($"[OrbitPOInts] Failed sampling {body?.bodyName ?? "<null>"}: {ex}");
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to update the max altitude for a body. Updates the failed set.
+        /// </summary>
+        /// <param name="body"></param>
+        /// <param name="value"></param>
+        private void UpdateBodyMaxAltitude(CelestialBody body, out double value)
+        {
+            if (TryGetBodyMaxAltitude(body, out value))
+            {
+                _bodyFailedMaxAltitudeSet.Remove(body);
+            }
+            else
+            {
+                _bodyFailedMaxAltitudeSet.Add(body);
+            }
+        }
+
+        /// <summary>
+        /// Initializes the body to max altitude dictionary.
+        /// </summary>
+        /// <returns></returns>
+        private Dictionary<CelestialBody,double> Initialize()
+        {
+
+            var dict = new Dictionary<CelestialBody,double>();
+            var bodies = FlightGlobals.Bodies ?? new List<CelestialBody>();
+
+            foreach (var body in bodies.Where(body => body))
+            {
+                UpdateBodyMaxAltitude(body, out var value);
+                // IMPORTANT: always add the body, even if PQS was not used
+                dict[body] = value;
+            }
+            return dict;
         }
 
 

--- a/OrbitPOInts/CelestialBodyCache.cs
+++ b/OrbitPOInts/CelestialBodyCache.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using OrbitPOInts.Extensions.KSP;
+using Enumerable = System.Linq.Enumerable;
 
 #if TEST
 using System.Linq;
+using UnityEngineMock;
 using KSP_CelestialBody = KSPMock.CelestialBody;
 using KSP_FlightGlobals = KSPMock.FlightGlobals;
 using JB_Annotations = UnityEngineMock.JetBrains.Annotations;
@@ -25,12 +28,49 @@ namespace OrbitPOInts
     {
         private static CelestialBodyCache _instance;
         private IReadOnlyDictionary<string, CelestialBody> _nameToBodyDictionary;
-        private IReadOnlyDictionary<CelestialBody, double> _bodyToMaxAltitudeDictionary;
+        private ReadOnlyDictionary<CelestialBody,double> _bodyToMaxAltitudeDictionary;
 
         public static CelestialBodyCache Instance => _instance ??= new CelestialBodyCache();
         public IReadOnlyDictionary<string, CelestialBody> NameToBodyDictionary => _nameToBodyDictionary ??= new ReadOnlyDictionary<string, CelestialBody>(FlightGlobals.Bodies.ToDictionary(body => body.name));
         // TODO: might be better to calculate these on demand instead of all on first access
-        public IReadOnlyDictionary<CelestialBody, double> BodyToMaxAltitudeDictionary => _bodyToMaxAltitudeDictionary ??= new ReadOnlyDictionary<CelestialBody, double>(FlightGlobals.Bodies.ToDictionary(body => body, body => body.GetApproxTerrainMaxHeight() + body.Radius));
+        public IReadOnlyDictionary<CelestialBody,double> BodyToMaxAltitudeDictionary
+        {
+            get
+            {
+                if (_bodyToMaxAltitudeDictionary != null) return _bodyToMaxAltitudeDictionary;
+
+                var dict = new Dictionary<CelestialBody,double>();
+                var bodies = FlightGlobals.Bodies ?? new List<CelestialBody>();
+
+                foreach (var body in bodies.Where(body => body))
+                {
+                    try
+                    {
+                        // Skip bodies without usable PQS (e.g., Sun, some gas giants or not ready)
+                        if (!body.IsPqsUsable())
+                        {
+                            Debug.LogWarning($"[OrbitPOInts] Skipping {body.bodyName} (no usable PQS).");
+                            continue;
+                        }
+
+                        var max = body.GetApproxTerrainMaxHeight();
+                        var maxAlt = body.Radius + max;
+                        dict[body] = maxAlt;
+                        
+                        Debug.Log($"[OrbitPOInts] Cached {body.bodyName}: max terrain alt {maxAlt:N0} m");
+                    }
+                    catch (Exception ex)
+                    {
+                        // Skip bad body instead of failing the whole map
+                        Debug.LogError($"[OrbitPOInts] Failed sampling {body?.bodyName ?? "<null>"}: {ex}");
+                    }
+                }
+
+                _bodyToMaxAltitudeDictionary = new ReadOnlyDictionary<CelestialBody,double>(dict);
+                return _bodyToMaxAltitudeDictionary;
+            }
+        }
+
 
         private CelestialBodyCache()
         {

--- a/OrbitPOInts/CelestialBodyCache.cs
+++ b/OrbitPOInts/CelestialBodyCache.cs
@@ -30,6 +30,7 @@ namespace OrbitPOInts
         private IReadOnlyDictionary<string, CelestialBody> _nameToBodyDictionary;
         private Dictionary<CelestialBody,double> _bodyToMaxAltitudeDictionary;
         private ReadOnlyDictionary<CelestialBody, double> _bodyToMaxAltitudeDictionaryRO;
+        private static HashSet<CelestialBody> _bodyLoggedNoPQS = new ();
 
         public static CelestialBodyCache Instance => _instance ??= new CelestialBodyCache();
         public IReadOnlyDictionary<string, CelestialBody> NameToBodyDictionary => _nameToBodyDictionary ??= new ReadOnlyDictionary<string, CelestialBody>(FlightGlobals.Bodies.ToDictionary(body => body.name));
@@ -76,7 +77,13 @@ namespace OrbitPOInts
                 // Skip bodies without usable PQS (e.g., Sun, some gas giants or not ready)
                 if (!body.IsPqsUsable())
                 {
-                    Debug.LogWarning($"[OrbitPOInts] Skipping {body.bodyName} (no usable PQS).");
+                    // Log once per body
+                    // Prevents log spam for Sun / Jool
+                    if (_bodyLoggedNoPQS.Add(body))
+                    {
+                        Debug.LogWarning($"[OrbitPOInts] Skipping {body.bodyName} (no usable PQS).");
+                    }
+
                     return false;
                 }
 

--- a/OrbitPOInts/CelestialBodyCache.cs
+++ b/OrbitPOInts/CelestialBodyCache.cs
@@ -44,6 +44,8 @@ namespace OrbitPOInts
 
                 foreach (var body in bodies.Where(body => body))
                 {
+                    var value = body.Radius; // fallback
+                    
                     try
                     {
                         // Skip bodies without usable PQS (e.g., Sun, some gas giants or not ready)
@@ -53,17 +55,20 @@ namespace OrbitPOInts
                             continue;
                         }
 
-                        var max = body.GetApproxTerrainMaxHeight();
-                        var maxAlt = body.Radius + max;
-                        dict[body] = maxAlt;
+                        var max = body.GetApproxTerrainMaxHeight(/*res*/ 32);
+                        // store absolute surface radius at max terrain
+                        value = body.Radius + Math.Max(0, max);
                         
-                        Debug.Log($"[OrbitPOInts] Cached {body.bodyName}: max terrain alt {maxAlt:N0} m");
+                        Debug.Log($"[OrbitPOInts] Cached {body.bodyName}: max terrain alt {value:N0} m");
                     }
                     catch (Exception ex)
                     {
                         // Skip bad body instead of failing the whole map
                         Debug.LogError($"[OrbitPOInts] Failed sampling {body?.bodyName ?? "<null>"}: {ex}");
                     }
+                    
+                    // IMPORTANT: always add the body, even if PQS was not used
+                    dict[body] = value;
                 }
 
                 _bodyToMaxAltitudeDictionary = new ReadOnlyDictionary<CelestialBody,double>(dict);

--- a/OrbitPOInts/Extensions/KSP/CelestialBodyExtensions.cs
+++ b/OrbitPOInts/Extensions/KSP/CelestialBodyExtensions.cs
@@ -5,12 +5,16 @@ using System.Linq;
 using UnityEngineMock;
 using KSP_CelestialBody = KSPMock.CelestialBody;
 using KSP_FlightGlobals = KSPMock.FlightGlobals;
+using KSP_GameScenes = KSPMock.GameScenes;
+using KSP_HighLogic = KSPMock.HighLogic;
 using JB_Annotations = UnityEngineMock.JetBrains.Annotations;
 #else
 using UnityEngine;
 using UniLinq;
 using KSP_CelestialBody = CelestialBody;
 using KSP_FlightGlobals = FlightGlobals;
+using KSP_GameScenes = GameScenes;
+using KSP_HighLogic = HighLogic;
 using JB_Annotations = JetBrains.Annotations;
 #endif
 
@@ -19,11 +23,24 @@ namespace OrbitPOInts.Extensions.KSP
     using CelestialBody = KSP_CelestialBody;
     using FlightGlobals = KSP_FlightGlobals;
     using CanBeNull = JB_Annotations.CanBeNullAttribute;
+    using GameScenes = KSP_GameScenes;
+    using HighLogic = KSP_HighLogic;
 
     public static class CelestialBodyExtensions
     {
-        public static bool IsPqsUsable(this CelestialBody body) =>
-            body && body.pqsController && body.pqsController.isActiveAndEnabled;
+
+        public static bool IsPqsUsable(this CelestialBody body)
+        {
+            if (!body || !body.pqsController || !body.pqsController.isActiveAndEnabled) return false;
+
+            return HighLogic.LoadedScene switch
+            {
+                GameScenes.FLIGHT => FlightGlobals.ready,
+                GameScenes.TRACKSTATION => true,
+                GameScenes.SPACECENTER => true,
+                _ => false
+            };
+        }
         
         // TODO: scale sampleRes based on body.Radius
         public static double GetApproxTerrainMaxHeight(this CelestialBody body, int sampleResolution = 100)

--- a/OrbitPOInts/Extensions/KSP/CelestialBodyExtensions.cs
+++ b/OrbitPOInts/Extensions/KSP/CelestialBodyExtensions.cs
@@ -23,7 +23,7 @@ namespace OrbitPOInts.Extensions.KSP
     public static class CelestialBodyExtensions
     {
         public static bool IsPqsUsable(this CelestialBody body) =>
-            body?.pqsController && body.pqsController.isActiveAndEnabled;
+            body && body.pqsController && body.pqsController.isActiveAndEnabled;
         
         // TODO: scale sampleRes based on body.Radius
         public static double GetApproxTerrainMaxHeight(this CelestialBody body, int sampleResolution = 100)

--- a/OrbitPOInts/Settings.cs
+++ b/OrbitPOInts/Settings.cs
@@ -63,6 +63,15 @@ namespace OrbitPOInts
         {
             Dispose(false);
         }
+        
+        public static bool HasInstance => _instance is { IsDisposed: false };
+
+        public static bool TryGetInstance(out Settings settings)
+        {
+            settings = _instance;
+            return settings != null;
+        }
+
 
         private bool _disposed = false;
 
@@ -145,7 +154,7 @@ namespace OrbitPOInts
         {
             get
             {
-                if (_instance != null) return _instance;
+                if (HasInstance) return _instance;
                 lock (Padlock)
                 {
                     _instance ??= new Settings();

--- a/OrbitPOInts/UI/OptionsPopup.cs
+++ b/OrbitPOInts/UI/OptionsPopup.cs
@@ -53,7 +53,7 @@ namespace OrbitPOInts.UI
         internal void OnGUI()
         {
             if (!_showGUI) return;
-            GUI.skin = Settings.Instance.UseSkin ? HighLogic.Skin : null;
+            ToolbarUI.UpdateSkin();
             _windowRect = GUILayout.Window(1234567, _windowRect, DrawUI, "OrbitPOInts Options", WindowStyle.GetSharedDarkWindowStyle());
         }
 

--- a/OrbitPOInts/UI/SimpleColorPicker.cs
+++ b/OrbitPOInts/UI/SimpleColorPicker.cs
@@ -69,7 +69,7 @@ namespace OrbitPOInts.UI
         internal void OnGUI()
         {
             if (!_showGUI) return;
-            GUI.skin = Settings.Instance.UseSkin ? HighLogic.Skin : null;
+            ToolbarUI.UpdateSkin();
             _windowRect = GUILayout.Window(123456, _windowRect, DrawUI, _title, WindowStyle.GetSharedDarkWindowStyle());
         }
 

--- a/OrbitPOInts/UI/ToolbarUI.cs
+++ b/OrbitPOInts/UI/ToolbarUI.cs
@@ -480,7 +480,9 @@ namespace OrbitPOInts.UI
         private void CloseWindow()
         {
             LogDebug("CloseWindow");
-            if (!Settings.Instance.UseQuickEnableToggle)
+            // prevent re-initializing Settings
+            var shouldQuickToggle = Settings.TryGetInstance(out var s) && s.UseQuickEnableToggle;
+            if (!shouldQuickToggle)
             {
                 toolbarButton.SetFalse();
             }

--- a/OrbitPOInts/UI/ToolbarUI.cs
+++ b/OrbitPOInts/UI/ToolbarUI.cs
@@ -255,16 +255,19 @@ namespace OrbitPOInts.UI
             }
         }
 
+        public static void UpdateSkin()
+        {
+            GUI.skin = Settings.Instance.UseSkin ? HighLogic.Skin : null;
+        }
+
 
         private void OnGUI()
         {
-            if (showUI)
-            {
-                GUI.skin = Settings.Instance.UseSkin ? HighLogic.Skin : null;
-                windowRect = GUILayout.Window(12345, windowRect, DrawUI, "OrbitPOInts", WindowStyle.GetSharedDarkWindowStyle());
-                _colorPicker.OnGUI();
-                _optionsPopup.OnGUI();
-            }
+            if (!showUI) return;
+            UpdateSkin();
+            windowRect = GUILayout.Window(12345, windowRect, DrawUI, "OrbitPOInts", WindowStyle.GetSharedDarkWindowStyle());
+            _colorPicker.OnGUI();
+            _optionsPopup.OnGUI();
         }
 
         private static GUILayoutOption[] MergeOptions(GUILayoutOption[] optionsA, params GUILayoutOption[] optionsB) => optionsA.Concat(optionsB).ToArray();

--- a/OrbitPOInts/UI/ToolbarUI.cs
+++ b/OrbitPOInts/UI/ToolbarUI.cs
@@ -413,6 +413,9 @@ namespace OrbitPOInts.UI
             GUILayout.BeginVertical();
 
                 Controls.StandardCloseButton(CloseWindow, !Settings.Instance.UseTopRightCloseButton);
+                
+                // Prevent button from overlapping `Enabled` toggle
+                GUILayout.Space(5);
 
                 Settings.Instance.GlobalEnable = CWIL.WrapToggle(Settings.Instance.GlobalEnable,"Enabled");
 

--- a/UnityEngineMock/CoreEngineModule/Debug.cs
+++ b/UnityEngineMock/CoreEngineModule/Debug.cs
@@ -13,5 +13,10 @@ namespace UnityEngineMock
         {
             Console.WriteLine(message);
         }
+        
+        public static void LogWarning(string message)
+        {
+            Console.WriteLine(message);
+        }
     }
 }


### PR DESCRIPTION
Fixes CI

---

Fixes #13 
- Prevent initialization of Settings in specific situations where it's not needed
- Lazy load CelestialBody terrain max altitude cache on access
  - Ensure PQS is ready when sampling terrain
  - Retry all failed bodies when PQS was not available

--- 
Fixes #12 
- Adds 5px spacing
